### PR TITLE
pass command line args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# Gogland
+.idea/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Here is a sample config file with the default settings:
     root:              .
     tmp_path:          ./tmp
     build_name:        runner-build
+    args:              -bind=:8080
     build_log:         runner-build-errors.log
     valid_ext:         .go, .tpl, .tmpl, .html
     build_delay:       600

--- a/runner.conf.sample
+++ b/runner.conf.sample
@@ -1,6 +1,7 @@
 root:              .
 tmp_path:          ./tmp
 build_name:        runner-build
+args:              -bind=:8080
 build_log:         runner-build-errors.log
 valid_ext:         .go, .tpl, .tmpl, .html
 build_delay:       600

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -8,7 +8,7 @@ import (
 func run() bool {
 	runnerLog("Running...")
 
-	cmd := exec.Command(buildPath())
+	cmd := exec.Command(buildPath(), args()...)
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {

--- a/runner/settings.go
+++ b/runner/settings.go
@@ -21,6 +21,7 @@ var settings = map[string]string{
 	"root":              ".",
 	"tmp_path":          "./tmp",
 	"build_name":        "runner-build",
+	"args":              "",
 	"build_log":         "runner-build-errors.log",
 	"valid_ext":         ".go, .tpl, .tmpl, .html",
 	"build_delay":       "600",
@@ -120,6 +121,11 @@ func tmpPath() string {
 func buildName() string {
 	return settings["build_name"]
 }
+
+func args() []string {
+	return strings.Fields(settings["args"])
+}
+
 func buildPath() string {
 	return filepath.Join(tmpPath(), buildName())
 }


### PR DESCRIPTION
Define `args` in runner.conf to pass command line args for runner-build.